### PR TITLE
Color terminal & Ignoring the directory "resource_packs"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ server.properties
 *.txt
 prismarine.yml
 crashdumps/*
+resource_packs/
 
 # Common IDEs
 .idea/*

--- a/src/pocketmine/utils/Terminal.php
+++ b/src/pocketmine/utils/Terminal.php
@@ -57,7 +57,15 @@ abstract class Terminal{
 			if(isset($opts["disable-ansi"])){
 				self::$formattingCodes = false;
 			}else{
-				self::$formattingCodes = ((Utils::getOS() !== "win" and getenv("TERM") != "" and (!function_exists("posix_ttyname") or !defined("STDOUT") or posix_ttyname(STDOUT) !== false)) or isset($opts["enable-ansi"]));
+				$stdout = fopen("php://stdout", "w");
+				self::$formattingCodes = (isset($opts["enable-ansi"]) or ( //user explicitly told us to enable ANSI
+					stream_isatty($stdout) and //STDOUT isn't being piped
+					(
+						getenv('TERM') !== false or //Console says it supports colours
+						(function_exists('sapi_windows_vt100_support') and sapi_windows_vt100_support($stdout)) //we're on windows and have vt100 support
+					)
+				));
+				fclose($stdout);
 			}
 		}
 


### PR DESCRIPTION
### Description
The terminal was one color, I do not know why.

### Reason to modify
I do not like this console.

### Tests & Reviews
It was:![Imgur](https://i.imgur.com/z3gbNZG.png)
Became:![Imgur](https://i.imgur.com/xmVdXdI.png)
